### PR TITLE
Update common.js add detection of GSM 7bit characters

### DIFF
--- a/web/plugin/themes/common/jscss/common.js
+++ b/web/plugin/themes/common/jscss/common.js
@@ -101,15 +101,16 @@ function SmsTextCounter() {
 	return result;
 }
 
-function containsNonLatinCodepoints(s) {
-	return /[^\u0000-\u00ff]/.test(s);
+function isGSMAlphabet(text) {
+    var regexp = new RegExp("^[A-Za-z0-9 \\r\\n@£$¥èéùìòÇØøÅå\u0394_\u03A6\u0393\u039B\u03A9\u03A0\u03A8\u03A3\u0398\u039EÆæßÉ!\"#$%&'()*+,\\-./:;<=>?¡ÄÖÑÜ§¿äöñüà^{}\\\\\\[~\\]|\u20AC]*$");
+    return regexp.test(text);
 }
 
 function SmsSetCounter() {
 	var msg = document.fm_sendsms.message;
 	var ftr = document.fm_sendsms.msg_footer;
 	var msg_unicode = document.fm_sendsms.msg_unicode;
-	var detect = containsNonLatinCodepoints(msg.value + ftr.value);
+	var detect = !isGSMAlphabet(msg.value + ftr.value);
 	msg_unicode.checked = detect;
 	if (ftr.value.length > 0) {
 		document.forms.fm_sendsms.footerlen.value = ftr.value.length + 1;


### PR DESCRIPTION
Update detection of GSM 7bit characters

I've tested the detection of unicode characters when sending SMS and there's something wrong with the function. As I can see in this page, the expression searches for non-latin characters instead of gsm 7bit characters.

There's also a solution on the answers section:

http://stackoverflow.com/questions/12673120/how-to-detect-non-gsm-7-bit-alphabet-characters-in-input-field

I just updated web/plugin/themes/common/jscss/common.js adding the function:

function isGSMAlphabet(text) {
var regexp = new RegExp("^[A-Za-z0-9 \r\n@£$¥èéùìòÇØøÅå\u0394_\u03A6\u0393\u039B\u03A9\u03A0\u03A8\u03A3\u0398\u039EÆæßÉ!\"#$%&'()+,\-./:;<=>?¡ÄÖÑÜ§¿äöñüà^{}\\\[~\]|\u20AC]$");
return regexp.test(text);
}

And updated the function SmsSetCounter()

var detect = !isGSMAlphabet(msg.value);

and it seems to work properly.

I think It's critical to work in this issue because there's a possibility to send a great ammount of SMS without knowing that are encoded in Unicode, and the correct size is half of the standard ones
