### PR TITLE
Proxy patch

### DIFF
--- a/getcomposer.sh
+++ b/getcomposer.sh
@@ -8,7 +8,8 @@ echo
 echo "Please wait while this script downloading composer"
 echo
 
-php -r "readfile('https://getcomposer.org/installer');" | php >/dev/null 2>&1
+curl "https://getcomposer.org/installer" > composer-setup.php
+php -r "readfile('composer-setup.php');" | php >/dev/null 2>&1
 
 if [ -e "composer.phar" ]; then
 	#rm -f /usr/local/bin/composer /usr/local/bin/composer.phar >/dev/null 2>&1

--- a/install-playsms.sh
+++ b/install-playsms.sh
@@ -178,7 +178,8 @@ echo
 echo "Please wait while the install script downloading composer"
 echo
 
-php -r "readfile('https://getcomposer.org/installer');" | php >/dev/null 2>&1
+curl "https://getcomposer.org/installer" > composer-setup.php
+php -r "readfile('composer-setup.php');" | php >/dev/null 2>&1
 
 if [ -e "./composer.phar" ]; then
 	#rm -f /usr/local/bin/composer /usr/local/bin/composer.phar >/dev/null 2>&1


### PR DESCRIPTION
php readfile does not work behind a web proxy.  I modified the install scripts to pull the composer install using curl first, which pays attention to an http_proxy set in the environment.