### PR TITLE
This commit fixes issue #556

### DIFF
--- a/web/plugin/feature/sms_subscribe/fn.php
+++ b/web/plugin/feature/sms_subscribe/fn.php
@@ -173,9 +173,10 @@ function sms_subscribe_handle($list, $sms_datetime, $sms_sender, $subscribe_keyw
 			}
 		}
 		if ($message) {
+                        $unicode = core_detect_unicode($message);
 			$message = addslashes($message);
 			_log('sending reply u:' . $username . ' to:' . $sms_to . ' m:[' . $message . '] smsc:[' . $smsc . ']', 3, 'sms_subscribe_handle');
-			sendsms_helper($username, $sms_to, $message, 'text', '', $smsc, TRUE);
+			sendsms_helper($username, $sms_to, $message, 'text', $unicode, $smsc, TRUE);
 		}
 	}
 	return $ok;
@@ -301,8 +302,9 @@ function _sms_subscribe_member_expired($subscribe, $member) {
 		if (sms_subscribe_member_remove($member['member_id'])) {
 			_log('removed k:' . $subscribe['subscribe_keyword'] . ' member_id:' . $member['member_id'] . ' number:' . $member['member_number'], 3, '_sms_subscribe_member_expired');
 			if ($subscribe['expire_msg']) {
+                        	$unicode = core_detect_unicode($subscribe['expire_msg']);
 				_log('SMS k:' . $subscribe['subscribe_keyword'] . ' member_id:' . $member['member_id'] . ' number:' . $member['member_number'] . ' message:[' . $subscribe['expire_msg'] . ']', 3, '_sms_subscribe_member_expired');
-				sendsms_helper($c_username, $member['member_number'], $subscribe['expire_msg'], 'text', '', $subscribe['smsc'], TRUE);
+				sendsms_helper($c_username, $member['member_number'], $subscribe['expire_msg'], 'text', $unicode, $subscribe['smsc'], TRUE);
 			}
 		}
 	}


### PR DESCRIPTION
On sendsms_helper call (2 places), it was being passed '' as $unicode value, breaking SQL command. Fixed declaring $unicode and passing it.