### PR TITLE
Multiline message templates

### DIFF
--- a/web/plugin/feature/msgtemplate/msgtemplate.php
+++ b/web/plugin/feature/msgtemplate/msgtemplate.php
@@ -77,7 +77,7 @@ switch (_OP_) {
 				<td class=label-sizer>"._('Message template name')."</td><td><input type=text maxlength=100 name=t_title></td>
 			</tr>
 			<tr>
-				<td>"._('Message template content')."</td><td><input type=text name=t_text></td>
+				<td>"._('Message template content')."</td><td><textarea type=text name=t_text></textarea></td>
 			</tr>	
 			</table>	
 			<p><input type='submit' class='button' value='"._('Save')."'></p>
@@ -101,7 +101,7 @@ switch (_OP_) {
 				<td class=label-sizer>"._('Message template name')."</td><td><input type=text maxlength=100 name=t_title value='".$db_row['t_title']."'></td>
 			</tr>
 			<tr>
-				<td>"._('Message template content')."</td><td><input type=text name=t_text value='".$db_row['t_text']."'></td>
+				<td>"._('Message template content')."</td><td><textarea type=text name=t_text>".$db_row['t_text']."</textarea></td>
 			</tr>
 			</table>
 			<input type='hidden' name='item_count' value='$i'>


### PR DESCRIPTION
Line breaks weren't possible in templates unless manually editing db records.

It's probably worth reviewing all such output to run db data through `htmlspecialchars()` before outputting it, to prevent corruption and XSS issues.